### PR TITLE
Fixed manual entry delete functionality

### DIFF
--- a/client/src/components/OurManualRecordsTable.js
+++ b/client/src/components/OurManualRecordsTable.js
@@ -142,17 +142,23 @@ const toolbarStyles = theme => ({
 let EnhancedTableToolbar = props => {
   const { numSelected, classes, selected, tokenId, publicKey, refetchData, handleClose } = props;
 
-  const deleteSelected = async (forDeletion) => {
-    let currentManualData = localStorage.getItem("manualAccountEntries") ? JSON.parse(localStorage.getItem("manualAccountEntries")) : false;
-    if(currentManualData[publicKey] && currentManualData[publicKey][tokenId]){
-      if(currentManualData[publicKey][tokenId].timeseries && currentManualData[publicKey][tokenId].timeseries.length > 1) {
-        currentManualData[publicKey][tokenId].timeseries = currentManualData[publicKey][tokenId].timeseries.filter((item, index) => forDeletion.indexOf(index) === -1)
-      }else{
-        delete currentManualData[publicKey][tokenId];
-        if(Object.entries(currentManualData[publicKey]).length < 2) {
-          delete currentManualData[publicKey];
-        }
+  const deleteSelected = (forDeletion) => {
+    const publicKeyLower = publicKey.toLowerCase();
+    const currentManualData = localStorage.getItem("manualAccountEntries")
+      ? JSON.parse(localStorage.getItem("manualAccountEntries"))
+      : false;
+
+    if (currentManualData[publicKeyLower] && currentManualData[publicKeyLower][tokenId]){
+      if (currentManualData[publicKeyLower][tokenId].timeseries && currentManualData[publicKeyLower][tokenId].timeseries.length > 1)
+        currentManualData[publicKeyLower][tokenId].timeseries =
+          currentManualData[publicKeyLower][tokenId].timeseries
+            .filter((_, index) => forDeletion.indexOf(index) === -1)
+      else {
+        delete currentManualData[publicKeyLower][tokenId];
+        if(Object.entries(currentManualData[publicKeyLower]).length < 2)
+          delete currentManualData[publicKeyLower];
       }
+
       localStorage.setItem("manualAccountEntries", JSON.stringify(currentManualData));
       refetchData();
       handleClose();


### PR DESCRIPTION
There was a bug on deleting manual entry records.

I found out that it's because the public key saved in local storage is always lower case but the delete function props has it in the case that was copied into the params. Obviously that means it doesn't match when trying to find out what to delete so clicking delete just goes ignored.

So I just transformed the key to lowercase before checking and that seems to have resolved it.

Guess that was an edge case since in developing it initially you most like had your public key in url in lowercase every time anyway.

I assume that Ethereum wallet address casings matter so it might be worth changing things up to always save the keys without transforming address casing, but this is just a quick simple isolated fix the functionality for now :)